### PR TITLE
Update scramble.py

### DIFF
--- a/scramble.py
+++ b/scramble.py
@@ -1,8 +1,8 @@
-import random
+import numpy
 
 def generate_order():
     alphabet = ['A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z']
-    random.shuffle(alphabet)
+    numpy.random.shuffle(alphabet)
     return "".join(alphabet)
 
 print(generate_order())


### PR DESCRIPTION
numpy.random.shuffle is significantly faster than random.shuffle

```python
import time
import random
import numpy


def generate_order_list():
    alphabet = ['A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z']
    random.shuffle(alphabet)
    return "".join(alphabet)


def generate_order_list_numpy():
    alphabet = ['A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z']
    numpy.random.shuffle(alphabet)
    return "".join(alphabet)


start = time.perf_counter()
for _ in range(1000):
  generate_order_list()
end = time.perf_counter()
print(end-start) #returned 0.007500000000000007


start = time.perf_counter()
for _ in range(1000):
  generate_order_list_numpy()
end = time.perf_counter()
print(end-start) #returned 0.0016855999999999816

```